### PR TITLE
Add 0x5C ("\") support in path.getExtension; fix typo (trully -> truly) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Garry's Mod Lua project aimed at expanding the game's functionality and improvin
 
 The project includes a package manager and supports many third-party APIs. The framework itself greatly expands the capabilities of developers for designing complex and comprehensive systems and games based on Garry's Mod.
 
-After many years of hard work I can finally say that we have created a trully powerful runtime for developers ;>
+After many years of hard work I can finally say that we have created a truly powerful runtime for developers ;>
 
 ## Bugs and Suggestions
 If you have any ideas or found a bug or error, please report it to us, we will try to fix it or explain what the problem is.

--- a/lua/dreamwork/std/path.lua
+++ b/lua/dreamwork/std/path.lua
@@ -147,7 +147,7 @@ path.getDirectory = getDirectory
 function path.getExtension( file_path, keep_dot )
     for index = string_len( file_path ), 1, -1 do
         local byte = string_byte( file_path, index )
-        if byte == 0x2F --[[ / ]] then
+        if byte == 0x2F --[[ / ]] or byte == 0x5C --[[ \ ]] then
             break
         elseif byte == 0x2E --[[ . ]] then
             if not keep_dot then


### PR DESCRIPTION
* Added Windows backslash (`\, 0x5C`) support in path.getExtension.
* Fixed typo in README: trully → truly.